### PR TITLE
add multi-OS support and cleaned up package dependencies

### DIFF
--- a/build-cac-enabled-git
+++ b/build-cac-enabled-git
@@ -19,8 +19,10 @@ Sys_git=/usr/bin/git
 Card_id=
 # Facilitate skipping install step when --no-install specified
 Make_install="make install"
-# System type: cygwin32 | cygwin64 | linux
+# Supported system types: cygwin32 | cygwin64 | linux
+# Supported operating systems: cygwin | ubuntu | debian | centos | redhat | fedora
 System_type=
+OS=
 
 declare -i Step_idx=0
 # Container for steps specified with --skip-step
@@ -346,29 +348,64 @@ detect_system() {
 	local -l machine=$(uname -m)
 	local -l version=$(uname -v)
 
-	# Default to generic Linux.
-	System_type=linux
-
-	# Check system (kernel)
-	# Note: -o would be more convenient, but it's an illegal option on some systems (e.g., OS X);
-	# -s is valid on *all* systems, -m is valid on Cygwin.
-	case $system in
-		*cygwin*)
-			# Check machine type (32/64-bit)
-			case $machine in
-				x86_64)
-					System_type=cygwin64;;
-				*)
-					# Default to safest choice.
-					System_type=cygwin32;;
-			esac;;
-		*linux*)
-			case $version in
-				*ubuntu*)
-					# Don't really care about machine type (confirm)
-					System_type=ubuntu;;
-			esac;;
-	esac
+	if grep -iq cygwin <<< ${system}
+	then
+		if [[ $machine == x86_64 ]]
+		then
+			System_type='cygwin64'
+		else
+			System_type='cygwin32'
+		fi
+		Installer=
+	elif type sw_vers >/dev/null 2>&1  && [[ `sw_vers` == *"Mac"* ]]
+	then
+		System_type='mac'
+		OS='macos'
+		Installer=
+	else
+		C1=`echo /etc/*_ver*`
+		C2=`echo /etc/*-rel*`
+		C3=`cat /etc/*_ver* 2>/dev/null`
+		C4=`cat /etc/*-rel* 2>/dev/null`
+		CONTENT="${C1} ${C2} ${C3} ${C4}"
+		if grep -iq Ubuntu <<< ${CONTENT}
+		then
+			System_type='linux'
+			OS='ubuntu'
+			Installer='apt-get'
+		elif grep -iq Debian <<< ${CONTENT}
+		then
+			System_type='linux'
+			OS='debian'
+			Installer='apt-get'
+		elif grep -iq CentOS <<< ${CONTENT}
+		then
+			System_type='linux'
+			OS='centos'
+			Installer='yum'
+		elif grep -iq 'Red Hat' <<< ${CONTENT}
+		then
+			System_type='linux'
+			OS='redhat'
+			Installer='yum'
+		elif grep -iq 'Fedora' <<< ${CONTENT}
+		then
+			System_type='linux'
+			OS='fedora'
+			Installer='yum'
+		else
+			System_type='unknown'
+			OS='other'
+			Installer=
+		fi
+		if [[ $Installer == yum ]]
+		then
+			if which dnf
+			then
+				Installer='dnf'
+			fi
+		fi
+	fi
 }
 # Assumption: errexit option has not yet been enabled.
 process_opt() {
@@ -561,7 +598,15 @@ do_prereq_cygwin32() {
 do_prereq_cygwin64() {
 	do_prereq_cygwin "$@"
 }
-do_prereq_ubuntu() {
+do_prereq_mac() {
+	log --ts "Mac OS X is not supported...exiting"
+	exit -1
+}
+do_prereq_unknown() {
+	log --ts "Unknown OS is not supported...exiting"
+	exit -1
+}
+do_prereq_linux() {
 	# Notes:
 	# git needed to obtain source
 	# libssl-dev needed so that OpenSSL can be found
@@ -569,33 +614,27 @@ do_prereq_ubuntu() {
 	# Note: nss is needed, but it appears to be part of ubuntu by default.
 	# TODO: Add libiconv-dev
 	# TODO: Consider adding gcc, make, etc..., but should already be there...
-	local -a pkgs=(
-		openssl libssl-dev
-		git autoconf automake m4 libtool
-		gettext libexpat1-dev
-		libpcsclite-dev
-	)
-	log --ts "Installing ubuntu prerequisite packages: ${pkgs[@]}..."
+	if [[ $OS == centos || $OS == redhat || $OS == fedora ]]
+	then
+		local -a pkgs=(
+			openssl wget patch openssl-devel
+			git autoconf automake m4 libtool
+			gettext pcsc-lite-devel expat-devel
+			perl-CPAN
+		)
+	else
+		local -a pkgs=(
+			openssl libssl-dev wget pkg-config
+			git autoconf automake m4 libtool
+			gettext libexpat1-dev
+			libpcsclite-dev
+		)
+	fi
+	log --ts "Installing linux prerequisite packages: ${pkgs[@]}..."
 	# Assumption: Script is running with root privileges (e.g., sudo).
 	# Note: Suppress tty prompt.
-	apt-get install -y "${pkgs[@]}"
-	log --ts "Finished installing ubuntu prerequisite packages..."
-}
-do_prereq_linux() {
-	# Generic Linux
-	# TODO: Inform user of what packages are needed, and present him with options: e.g.,
-	# 1) I have them. Proceed.
-	# 2) I don't have them. Abort.
-	# TODO: Remove stuff below...
-	# Design Decision: For now, just check the easy stuff: things that can be checked without
-	# autoconf, etc...
-	local -a exes=(git make patch)
-	for exe in "${exes[@]}"; do
-		if ! which "$exe" &>/dev/null; then
-			error "Prerequisite not met: Cannot proceed without a working \`$exe'. Use your" \
-			"package manager to install, then re-run."
-		fi
-	done
+	${Installer} install -y "${pkgs[@]}"
+	log --ts "Finished installing linux prerequisite packages..."
 }
 # Make sure there's nothing in the environment (e.g., from a previous run), that could mess us up (e.g., GIT_SSL_<...>
 # vars that could cause the vanilla git to attempt to use the CAC card).
@@ -937,6 +976,7 @@ install_env_script() {
 }
 
 detect_system
+log --ts "System type is ${System_type}, OS is ${OS}, and installer is ${Installer}..."
 process_opt "$@"
 post_process_opt
 clean_env


### PR DESCRIPTION
Brett,

I have edited the build-cac-enabled-git script to use a different method to identify the OS and modified the list of required packages so that everything builds on, at least, Debian, Ubuntu, CentOS, and Fedora.  I have not changed the README.md file -- that should be (slightly) updated.

I have tested all the steps EXCEPT steps 3 & 10.  I haven't tested 3 & 10 because I'm still waiting for a CAC (!).  I didn't test on Red Hat Enterprise Linux b/c I don't have a key, but it and CentOS should behave the same.  I also didn't test on Cygwin (again, no system to test).  If you still have access to a Cygwin system it would be good to test that & be sure I didn't mess anything up -- I didn't change (intentionally) the Cygwin-specific code.  The behavior on Ubuntu should also be the same as before.  Perhaps someone else can check the RHEL build (or I might be able to impose on a friend...).

The test for a Mac OS X system is for future use -- the problem there being the complexity of the installer and absence of a uniform set of pre-built packages.  Any systems other than those listed are flagged as "unknown".  Both Mac OS X and unknown cause graceful exits.  Other Linux/UNIX systems can easily be added (with some experimentation to determine which packages to install and, possibly, the installer to use) -- the approach I am using to identify the OS is quite general.  See http://linuxmafia.com/faq/Admin/release-files.html for more information.

Once I get a CAC & a CAC-enabled server I can point to, I will test steps 3 & 10, and execution.  I'm using docker for all the tests. (Example, once you have the docker service installed and running: "docker run -ti -v /absolute-path-to-local-dir:/absolute-path-to-dir-in-container ubuntu:latest /bin/bash", followed by "apt-get update; apt-get install build-essential" in the container, followed by ./build-cac-enabled-git {options}.  Substitute debian:latest, centos:latest, rhel:latest, or fedora:latest as needed, and the appropriate installer -- note that rhel requires a key before it will allow yum to install things.)  I used docker and this approach in part because I wanted to be sure the build works when starting with a minimal development environment.

Note that the script does not check to ensure that the development/build tools have been installed -- the previous version doesn't do this, either.  For Debian/Ubuntu this can be done with "apt-get install build-essential"; for CentOS/Fedora/RHEL the command is "yum groupinstall 'Development Tools'" (or dnf instead of yum if dnf exists).  "apt-get/yum/dnf update" should be executed before this.

One more thing to attempt in the future is to use apt-get/yum/dnf to install OpenSC rather than build by source.  The OpenSC folks replied to my issue and said they have no control over the old versions associated with the various distributions.

Doug
